### PR TITLE
Rename "xhr" var to "sync".

### DIFF
--- a/ampersand-model.js
+++ b/ampersand-model.js
@@ -5,7 +5,7 @@ var sync = require('ampersand-sync');
 
 var Model = State.extend({
     save: function (key, val, options) {
-        var attrs, method, xhr, attributes = this.attributes;
+        var attrs, method, sync, attributes = this.attributes;
 
         // Handle both `"key", value` and `{key: value}` -style arguments.
         if (key == null || typeof key === 'object') {
@@ -47,9 +47,9 @@ var Model = State.extend({
         // if we're waiting we haven't actually set our attributes yet so
         // we need to do make sure we send right data
         if (options.wait) options.attrs = _.extend(model.serialize(), attrs);
-        xhr = this.sync(method, this, options);
+        sync = this.sync(method, this, options);
 
-        return xhr;
+        return sync;
     },
 
     // Fetch the model from the server. If the server's representation of the
@@ -93,9 +93,9 @@ var Model = State.extend({
         }
         wrapError(this, options);
 
-        var xhr = this.sync('delete', this, options);
+        var sync = this.sync('delete', this, options);
         if (!options.wait) destroy();
-        return xhr;
+        return sync;
     },
 
     // Proxy `ampersand-sync` by default -- but override this if you need


### PR DESCRIPTION
Depending on the sync implementation this.sync may not return an xhr object. For example when someone would make a LocalStorage provider for ampersand-sync. It's best to rename the var to avoid the confusion that ampersand-model is restricted to the XHR objects.
