### PR TITLE
Fix incorrect argument name

### DIFF
--- a/ampersand-model.js
+++ b/ampersand-model.js
@@ -123,7 +123,7 @@ var urlError = function () {
 // Wrap an optional error callback with a fallback error event.
 var wrapError = function (model, options) {
     var error = options.error;
-    options.error = function (model, resp, options) {
+    options.error = function (xhr, resp, options) {
         if (error) error(model, resp, options);
         model.trigger('error', model, resp, options);
     };


### PR DESCRIPTION
The first argument passed to the error callback is a XMLHttpRequest, not the model.

This overwrites the previous scope's model variable with the XMLHttpRequest which does not have a trigger method.

Could also point to an error in ampersand-sync passing the wrong arguments.