### PR TITLE
Update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
     "url": "https://github.com/ampersandjs/ampersand-model/issues"
   },
   "dependencies": {
-    "ampersand-state": "^4.5.0",
-    "ampersand-sync": "^3.0.4",
+    "ampersand-state": "^4.5.2",
+    "ampersand-sync": "^3.0.5",
     "ampersand-version": "^1.0.2",
     "lodash.assign": "^3.0.0",
     "lodash.clone": "^3.0.1",


### PR DESCRIPTION
`ampersand-state` and `ampersand-sync` that use `lodash.includes` (vs. `lodash.contains`)