### PR TITLE
readd browserify transform to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,11 @@
     "publish-minor": "npm run preversion && npm version minor && git push origin master --tags && npm publish",
     "publish-major": "npm run preversion && npm version major && git push origin master --tags && npm publish"
   },
+  "browserify": {
+    "transform": [
+      "ampersand-version"
+    ]
+  },
   "pre-commit": [
     "lint",
     "validate",


### PR DESCRIPTION
Accidentally took this out, forgot it was part of how ampersand-version works.