### PR TITLE
Fix code typo in model.save section

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ If you only want the changed attributes to be sent to the server, call `model.sa
 Calling save with new attributes will cause a `"change"` event immediately, a `"request"` event as the Ajax request begins to go to the server, and a `"sync"` event after the server has acknowledged the successful change. Pass `{wait: true}` if you'd like to wait for the server before setting the new attributes on the model.
 
 ```javascript
-var book = new Backbone.Model({
+var book = new AmpersandModel({
   title: "The Rough Riders",
   author: "Theodore Roosevelt"
 });


### PR DESCRIPTION
Noticed this inconsistency in the model.save section. I'm guessing this code example was slightly copied from the original Backbone docs, see: http://devdocs.io/backbone/index#Model-save