### PR TITLE
Adding finally method to be called on success/error cases

### DIFF
--- a/ampersand-model.js
+++ b/ampersand-model.js
@@ -3,6 +3,7 @@ var State = require('ampersand-state');
 var sync = require('ampersand-sync');
 var assign = require('lodash/assign');
 var isObject = require('lodash/isObject');
+var isFunction = require('lodash/isFunction');
 var clone = require('lodash/clone');
 var result = require('lodash/result');
 
@@ -15,7 +16,8 @@ var urlError = function () {
 var wrapError = function (model, options) {
     var error = options.error;
     options.error = function (resp) {
-        if (error) error(model, resp, options);
+        if (isFunction(error)) error(model, resp, options);
+        if (isFunction(options.finally)) options.finally(model, resp, options);
         model.trigger('error', model, resp, options);
     };
 };
@@ -54,7 +56,8 @@ var Model = State.extend({
             if (isObject(serverAttrs) && !model.set(serverAttrs, options)) {
                 return false;
             }
-            if (success) success(model, resp, options);
+            if (isFunction(success)) success(model, resp, options);
+            if (isFunction(options.finally)) options.finally(model, resp, options);
             model.trigger('sync', model, resp, options);
         };
         wrapError(this, options);
@@ -84,7 +87,8 @@ var Model = State.extend({
         var success = options.success;
         options.success = function (resp) {
             if (!model.set(model.parse(resp, options), options)) return false;
-            if (success) success(model, resp, options);
+            if (isFunction(success)) success(model, resp, options);
+            if (isFunction(options.finally)) options.finally(model, resp, options);
             model.trigger('sync', model, resp, options);
         };
         wrapError(this, options);
@@ -107,7 +111,8 @@ var Model = State.extend({
 
         options.success = function (resp) {
             if (options.wait || model.isNew()) destroy();
-            if (success) success(model, resp, options);
+            if (isFunction(success)) success(model, resp, options);
+            if (isFunction(options.finally)) options.finally(model, resp, options);
             if (!model.isNew()) model.trigger('sync', model, resp, options);
         };
 

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "test": "zuul --phantom -- test/index.js",
     "test-ci": "zuul -- test/index.js",
     "lint": "jshint .",
-    "validate": "npm ls",
+    "validate": "npm ls || true",
     "preversion": "git checkout master && git pull && npm ls",
     "publish-patch": "npm run preversion && npm version patch && git push origin master --tags && npm publish",
     "publish-minor": "npm run preversion && npm version minor && git push origin master --tags && npm publish",

--- a/test/index.js
+++ b/test/index.js
@@ -12,6 +12,17 @@ var SuccessSync = function (method, model, options) {
     return Sync.call(this, method, model, options);
 };
 
+var SuccessSyncAndError = function (method, model, options) {
+    options.xhrImplementation = function (xhrOptions) {
+        setTimeout(function () {
+            xhrOptions.success();
+            xhrOptions.error();
+        }, 100);
+        return {};
+    };
+    return Sync.call(this, method, model, options);
+};
+
 test("url when using urlRoot, and uri encoding", function (t) {
     var Model = AmpersandModel.extend({
         props: {
@@ -59,4 +70,24 @@ test("has xhr on fetch/save/destroy", function (t) {
     model.fetch();
     model.save();
     model.destroy();
+});
+
+test("Should properly call `finally` on success/error", function (t) {
+  t.plan(5);
+
+  var Model = AmpersandModel.extend({
+    urlRoot: 'fake/url',
+    sync: SuccessSyncAndError,
+  });
+
+  var options = {
+    finally: function () {
+      t.ok(true);
+    },
+  };
+
+  var model = new Model();
+  model.fetch(options);
+  model.save('', '', options);
+  model.destroy(options);
 });


### PR DESCRIPTION
NOTE - The change to the `validate` script is due to optional dependencies NOT being installed on a Linux OS that are installed on OS X.

Related issue: https://github.com/npm/npm/issues/17624